### PR TITLE
fix incorrect sunset time

### DIFF
--- a/i3/scripts/taskbar.py
+++ b/i3/scripts/taskbar.py
@@ -304,6 +304,7 @@ def get_peak_times(location, skip=False):
 
         sunrise += offset
         sunset  += offset
+        sunset = sunset.replace(day=sunrise.day)
 
     return (
         (sunrise - timedelta(minutes=30),


### PR DESCRIPTION
When trying out your script i noticed it was giving a moon(🌙) when it should have given a sun(☀). Turns out when getting the sunrise and sunset times and converting to local timezone it was setting the sunset time in the past due to having a negative offset. This is my simple fix